### PR TITLE
Feature/smallCleanup

### DIFF
--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -35,7 +35,10 @@ const Map = ({ pins, pin }: MapProps) => {
           (pin) =>
             pin.fields.lat && (
               <Marker key={pin.id} position={[pin.fields.lat, pin.fields.lng]}>
-                <Popup>Name: {pin.fields.name}</Popup>
+                <Popup>
+                  {pin.fields.city && `${pin.fields.city} - `}People:{' '}
+                  {pin.fields.groupSize}
+                </Popup>
               </Marker>
             )
         )}

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -13,7 +13,7 @@ const Map = ({ pins, pin }: MapProps) => {
       zoom={pin ? 9 : 6}
       scrollWheelZoom={false}
       style={{
-        height: 400,
+        height: pin ? 400 : 600,
         width: '100%',
         zIndex: '0',
         borderRadius: '0rem 0rem 0.5rem 0.5rem',

--- a/components/signupForm/signupForm.tsx
+++ b/components/signupForm/signupForm.tsx
@@ -97,8 +97,7 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
           location,
         },
       });
-      const { latitude, longitude } = data;
-      return [latitude, longitude];
+      return data;
     } catch (error: any) {
       console.error(error);
     }
@@ -116,7 +115,7 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
     setError('');
 
     try {
-      const [lat, lng] = await retrieveLatLng(
+      const locationData = await retrieveLatLng(
         values.city || countryAbbrs[values.country]
       );
 
@@ -127,8 +126,7 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
         name: session?.user?.name,
         email: session?.user?.email,
         avatar: session?.user?.image,
-        lat,
-        lng,
+        ...locationData,
       };
 
       await axios({
@@ -207,12 +205,14 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
                 : labels.cityLabelHost[language]
             }
             placeholder={labels.cityPlaceholder[language]}
-            data={citiesOptions[
-              form.values.country as keyof typeof citiesOptions
+            data={[
+              ...new Set(
+                citiesOptions[form.values.country as keyof typeof citiesOptions]
+              ),
             ]
               .sort(sortAlphabetically)
-              .map((city, index) => ({
-                value: `${city}-${index}`,
+              .map((city) => ({
+                value: city,
                 label: city,
               }))}
           />

--- a/components/signupForm/signupForm.tsx
+++ b/components/signupForm/signupForm.tsx
@@ -104,6 +104,13 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
     }
   };
 
+  const sortAlphabetically = (a: string, b: string) => {
+    return a.localeCompare(b, 'en', {
+      sensitivity: 'base',
+      ignorePunctuation: true,
+    });
+  };
+
   const onSubmitHandler = async (values: typeof form['values']) => {
     setIsSubmitting(true);
     setError('');
@@ -202,10 +209,12 @@ export const SignupForm = ({ initialValues, method, url }: SignupFormProps) => {
             placeholder={labels.cityPlaceholder[language]}
             data={citiesOptions[
               form.values.country as keyof typeof citiesOptions
-            ].map((city, index) => ({
-              value: `${city}-${index}`,
-              label: city,
-            }))}
+            ]
+              .sort(sortAlphabetically)
+              .map((city, index) => ({
+                value: `${city}-${index}`,
+                label: city,
+              }))}
           />
 
           <DateRangePicker

--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -36,7 +36,7 @@ export const Table = ({ data, type }: TableProps) => {
         <td>
           {country || city ? (
             <>
-              {city} {country}
+              {city && `${city}, `} {country}
             </>
           ) : (
             '-'
@@ -106,7 +106,7 @@ export const Table = ({ data, type }: TableProps) => {
         <Group direction="column">
           <Avatar radius="xl" size="lg" src={avatar} alt="it's me" />
           <Text>
-            <b>Location:</b> {city} {country}
+            <b>Location:</b> {city && `${city}, `} {country}
           </Text>
           {lat && lng && <Map pin={{ lat, lng, city, country }} />}
           <Text>

--- a/pages/api/location.ts
+++ b/pages/api/location.ts
@@ -21,11 +21,10 @@ export default async function handler(
           ),
         });
 
+        if (!data.length) return res.status(201).json({ lat: null, lng: null });
+
         const { latitude, longitude } = data[0];
-
-        console.log(data);
-
-        return res.status(201).json({ latitude, longitude });
+        return res.status(201).json({ lat: latitude, lng: longitude });
       } catch (error: any) {
         console.log(error);
         return res.status(500).json({ error: error.message });

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -88,6 +88,8 @@ export default async function handler(
       dateStart: req.body.dateStart,
       dateEnd: req.body.dateEnd,
       userType: req.body.userType,
+      lat: req.body.lat,
+      lng: req.body.lng,
     };
 
     switch (req.method) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
1/ Possible cities of residence are now sorted alphabetically ( A -> Z ) when a user signs up or edit their profile.

![Screenshot 2022-03-14 at 11 55 48](https://user-images.githubusercontent.com/17719054/158167217-3eb127d3-bd5d-46f0-a2d1-dec3dad4294f.png)

2/ Small cosmetic changes (map height on main page, way city/country names are displayed on the pins / user profile / modals)

![Screenshot 2022-03-14 at 11 56 44](https://user-images.githubusercontent.com/17719054/158167351-369dbf23-21d8-4d0e-baeb-9306d4eeb953.png)

3/ Fix location issues:
- Remove duplicate cities from the citiesOptions array, fix React duplicate key issue, prevents adding an index in the DB
- Prevent throwing an error if no geolocation data is found when registering/editing (+ blank out lat/lng fields on a user's db entry if there was something held there previously)